### PR TITLE
fix: fix configuration error of hdfs discovery

### DIFF
--- a/bundle/manifests/hdfs-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hdfs-operator.clusterserviceversion.yaml
@@ -133,7 +133,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Big Data
-    createdAt: "2024-07-19T10:21:45Z"
+    createdAt: "2024-07-25T10:03:33Z"
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: hdfs-operator.v0.0.1

--- a/internal/common/hdfs_conf.go
+++ b/internal/common/hdfs_conf.go
@@ -21,8 +21,7 @@ const coreSiteTemplate = `<?xml version="1.0"?>
     <name>ha.zookeeper.quorum</name>
     <value>${env.ZOOKEEPER}</value>
   </property>
-</configuration> 
-`
+</configuration>`
 
 type CoreSiteXmlGenerator struct {
 	InstanceName string

--- a/internal/controller/discovery.go
+++ b/internal/controller/discovery.go
@@ -87,7 +87,7 @@ func (d *Discovery) commonHdfsSiteXml() []util.XmlNameValuePair {
 			Value: d.Instance.GetName(),
 		},
 		{
-			Name:  "dfs.client.failover.proxy.provider.simple-hdfs",
+			Name:  "dfs.client.failover.proxy.provider." + d.Instance.GetName(),
 			Value: "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
 		},
 	}
@@ -136,7 +136,7 @@ func (d *Discovery) getPodNames(nameNodeGroups map[string]*hdfsv1alpha1.NameNode
 func (d *Discovery) makeDiscoveryHosts(podNames []string) util.XmlNameValuePair {
 	return util.XmlNameValuePair{
 		Name:  "dfs.ha.namenodes." + d.Instance.GetName(),
-		Value: strings.Join(podNames, ", "),
+		Value: strings.Join(podNames, ","),
 	}
 }
 


### PR DESCRIPTION
it's `"dfs.client.failover.proxy.provider." + d.Instance.GetName()`, not `"dfs.client.failover.proxy.provider.simple-hdfs"`
