### PR TITLE
refactor: bump operator-go to 0.12-dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        First, check out our [Collaboration Guide](https://zncdata.dev/docs/developer-manual/collaboration)
+        First, check out our [Collaboration Guide](https://kubedoop.dev/docs/developer-manual/collaboration)
         Please provide a searchable summary of the issue in the title above ⬆️.
   - type: dropdown
     attributes:

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-domain: zncdata.dev
+domain: kubedoop.dev
 layout:
 - go.kubebuilder.io/v4
 projectName: hdfs-operator
@@ -12,7 +12,7 @@ resources:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: zncdata.dev
+  domain: kubedoop.dev
   group: hdfs
   kind: HdfsCluster
   path: github.com/zncdatadev/hdfs-operator/api/v1alpha1

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Kubedoop built-in operators:
 
 ## Contributing
 
-If you'd like to contribute to Kubedoop, please refer to our [Contributing Guide](https://zncdata.dev/docs/developer-manual/collaboration) for more information.
+If you'd like to contribute to Kubedoop, please refer to our [Contributing Guide](https://kubedoop.dev/docs/developer-manual/collaboration) for more information.
 We welcome contributions of all kinds, including but not limited to code, documentation, and use cases.
 
 ## License

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the hdfs v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=hdfs.zncdata.dev
+// +groupName=hdfs.kubedoop.dev
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "hdfs.zncdata.dev", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "hdfs.kubedoop.dev", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1alpha1/hdfscluster_types.go
+++ b/api/v1alpha1/hdfscluster_types.go
@@ -21,6 +21,8 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/status"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonsv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
 )
 
 // file name
@@ -119,8 +121,11 @@ type HdfsClusterSpec struct {
 	// +kubebuilder:validation:Optional
 	Image *ImageSpec `json:"image,omitempty"`
 
+	// +kubebuilder:validation:Optional
+	ClusterOperationSpec *commonsv1alpha1.ClusterOperationSpec `json:"clusterOperation,omitempty"`
+
 	// +kubebuilder:validation:Required
-	ClusterConfigSpec *ClusterConfigSpec `json:"clusterConfig,omitempty"`
+	ClusterConfig *ClusterConfigSpec `json:"clusterConfig,omitempty"`
 
 	// roles defined: nameNode, dataNode, journalNode
 	// +kubebuilder:validation:Required

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -400,8 +400,13 @@ func (in *HdfsClusterSpec) DeepCopyInto(out *HdfsClusterSpec) {
 		*out = new(ImageSpec)
 		**out = **in
 	}
-	if in.ClusterConfigSpec != nil {
-		in, out := &in.ClusterConfigSpec, &out.ClusterConfigSpec
+	if in.ClusterOperationSpec != nil {
+		in, out := &in.ClusterOperationSpec, &out.ClusterOperationSpec
+		*out = new(commonsv1alpha1.ClusterOperationSpec)
+		**out = **in
+	}
+	if in.ClusterConfig != nil {
+		in, out := &in.ClusterConfig, &out.ClusterConfig
 		*out = new(ClusterConfigSpec)
 		(*in).DeepCopyInto(*out)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -128,7 +128,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		WebhookServer:          webhookServer,
-		LeaderElectionID:       "377b9d1f.zncdata.dev",
+		LeaderElectionID:       "377b9d1f.kubedoop.dev",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/config/crd/bases/hdfs.kubedoop.dev_hdfsclusters.yaml
+++ b/config/crd/bases/hdfs.kubedoop.dev_hdfsclusters.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-  name: hdfsclusters.hdfs.zncdata.dev
+  name: hdfsclusters.hdfs.kubedoop.dev
 spec:
-  group: hdfs.zncdata.dev
+  group: hdfs.kubedoop.dev
   names:
     kind: HdfsCluster
     listKind: HdfsClusterList

--- a/config/crd/bases/hdfs.kubedoop.dev_hdfsclusters.yaml
+++ b/config/crd/bases/hdfs.kubedoop.dev_hdfsclusters.yaml
@@ -110,6 +110,16 @@ spec:
                   zookeeperConfigMapName:
                     type: string
                 type: object
+              clusterOperation:
+                description: ClusterOperationSpec defines the desired state of ClusterOperation
+                properties:
+                  reconciliationPaused:
+                    default: false
+                    type: boolean
+                  stopped:
+                    default: false
+                    type: boolean
+                type: object
               dataNode:
                 properties:
                   cliOverrides:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/hdfs.zncdata.dev_hdfsclusters.yaml
+- bases/hdfs.kubedoop.dev_hdfsclusters.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/crd/patches/cainjection_in_hdfsclusters.yaml
+++ b/config/crd/patches/cainjection_in_hdfsclusters.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
-  name: hdfsclusters.hdfs.zncdata.dev
+  name: hdfsclusters.hdfs.kubedoop.dev

--- a/config/crd/patches/webhook_in_hdfsclusters.yaml
+++ b/config/crd/patches/webhook_in_hdfsclusters.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: hdfsclusters.hdfs.zncdata.dev
+  name: hdfsclusters.hdfs.kubedoop.dev
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/hdfscluster_editor_role.yaml
+++ b/config/rbac/hdfscluster_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: hdfscluster-editor-role
 rules:
 - apiGroups:
-  - hdfs.zncdata.dev
+  - hdfs.kubedoop.dev
   resources:
   - hdfsclusters
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - hdfs.zncdata.dev
+  - hdfs.kubedoop.dev
   resources:
   - hdfsclusters/status
   verbs:

--- a/config/rbac/hdfscluster_viewer_role.yaml
+++ b/config/rbac/hdfscluster_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: hdfscluster-viewer-role
 rules:
 - apiGroups:
-  - hdfs.zncdata.dev
+  - hdfs.kubedoop.dev
   resources:
   - hdfsclusters
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - hdfs.zncdata.dev
+  - hdfs.kubedoop.dev
   resources:
   - hdfsclusters/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,7 +40,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - authentication.zncdata.dev
+  - authentication.kubedoop.dev
   resources:
   - authenticationclasses
   verbs:
@@ -48,7 +48,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - hdfs.zncdata.dev
+  - hdfs.kubedoop.dev
   resources:
   - hdfsclusters
   verbs:
@@ -60,13 +60,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - hdfs.zncdata.dev
+  - hdfs.kubedoop.dev
   resources:
   - hdfsclusters/finalizers
   verbs:
   - update
 - apiGroups:
-  - hdfs.zncdata.dev
+  - hdfs.kubedoop.dev
   resources:
   - hdfsclusters/status
   verbs:
@@ -74,7 +74,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - listeners.zncdata.dev
+  - listeners.kubedoop.dev
   resources:
   - listeners
   verbs:

--- a/config/samples/hdfs_v1alpha1_hdfscluster.yaml
+++ b/config/samples/hdfs_v1alpha1_hdfscluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: hdfs.zncdata.dev/v1alpha1
+apiVersion: hdfs.kubedoop.dev/v1alpha1
 kind: HdfsCluster
 metadata:
   labels:
@@ -73,4 +73,3 @@ spec:
                   level: DEBUG
               console:
                 level: WARN
-

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
 	github.com/stretchr/testify v1.9.0
-	github.com/zncdatadev/operator-go v0.11.2
+	github.com/zncdatadev/operator-go v0.11.3-0.20241120112858-dcdca6c6cd44
 	k8s.io/api v0.31.2
 	k8s.io/apimachinery v0.31.2
 	k8s.io/client-go v0.31.2

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zncdatadev/operator-go v0.11.2 h1:/3ti+26D9w38gZV2eQLIz62mPe45em3Ej8iePoSj/04=
 github.com/zncdatadev/operator-go v0.11.2/go.mod h1:Thc0Jo5LuXnwrb73shfI63PKlxC+7cGq7SClzo3Y5qI=
+github.com/zncdatadev/operator-go v0.11.3-0.20241120112858-dcdca6c6cd44 h1:wxxTwfas5UAX46FoinIC/ZmGc+dlk5I+1cT3McypY+4=
+github.com/zncdatadev/operator-go v0.11.3-0.20241120112858-dcdca6c6cd44/go.mod h1:9QGIaH5gTDgpv0kftcGkBGqCIj7cboC5ZMES9fZy4XI=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 h1:4K4tsIXefpVJtvA/8srF4V4y0akAoPHkIslgAkjixJA=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0/go.mod h1:jjdQuTGVsXV4vSs+CJ2qYDeDPf9yIJV23qlIzBm73Vg=
 go.opentelemetry.io/otel v1.28.0 h1:/SqNcYk+idO0CxKEUOtKQClMK/MimZihKYMruSMViUo=

--- a/internal/common/hdfs_conf.go
+++ b/internal/common/hdfs_conf.go
@@ -449,7 +449,7 @@ func NewDataNodeHdfsSiteXmlGenerator(
 	nameNodeReplicas int32,
 	dataNodeConfig map[string]string) *DataNodeHdfsSiteXmlGenerator {
 
-	clusterSpec := instance.Spec.ClusterConfigSpec
+	clusterSpec := instance.Spec.ClusterConfig
 	return &DataNodeHdfsSiteXmlGenerator{
 		NameNodeHdfsSiteXmlGenerator: *NewNameNodeHdfsSiteXmlGenerator(
 			instance.Name,

--- a/internal/common/hdfs_conf.go
+++ b/internal/common/hdfs_conf.go
@@ -272,15 +272,15 @@ func (c *NameNodeHdfsSiteXmlGenerator) makeNameNodeRpc() []util.XmlNameValuePair
 //
 //	<property>
 //		<name>dfs.namenode.name.dir.simple-hdfs.simple-hdfs-namenode-default-0</name>
-//		<value>/zncdata/data/namenode</value>
+//		<value>/kubedoop/data/namenode</value>
 //	</property>
 //	<property>
 //		<name>dfs.namenode.name.dir.simple-hdfs.simple-hdfs-namenode-default-1</name>
-//		<value>/zncdata/data/namenode</value>
+//		<value>/kubedoop/data/namenode</value>
 //	</property>
 //	<property>
 //		<name>dfs.namenode.name.dir.simple-hdfs.simple-hdfs-namenode-default-2</name>
-//		<value>/zncdata/data/namenode</value>
+//		<value>/kubedoop/data/namenode</value>
 //	</property>
 func (c *NameNodeHdfsSiteXmlGenerator) makeNameNodeNameDir() []util.XmlNameValuePair {
 	statefulSetName := CreateNameNodeStatefulSetName(c.InstanceName, c.GroupName)

--- a/internal/common/kerberos.go
+++ b/internal/common/kerberos.go
@@ -201,7 +201,7 @@ func CreateKerberosSecretPvc(secretClass string, instanceName string, role Role)
 					Spec: corev1.PersistentVolumeClaimSpec{
 						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 						StorageClassName: func() *string {
-							cs := "secrets.zncdata.dev"
+							cs := "secrets.kubedoop.dev"
 							return &cs
 						}(),
 						VolumeMode: func() *corev1.PersistentVolumeMode { v := corev1.PersistentVolumeFilesystem; return &v }(),

--- a/internal/common/oidc.go
+++ b/internal/common/oidc.go
@@ -28,15 +28,15 @@ func MakeOidcContainer(
 	port int32,
 ) (*corev1.Container, error) {
 	authClass := &authv1alpha1.AuthenticationClass{}
-	if err := client.Get(ctx, ctrlclient.ObjectKey{Namespace: instance.Namespace, Name: instance.Spec.ClusterConfigSpec.Authentication.AuthenticationClass}, authClass); err != nil {
+	if err := client.Get(ctx, ctrlclient.ObjectKey{Namespace: instance.Namespace, Name: instance.Spec.ClusterConfig.Authentication.AuthenticationClass}, authClass); err != nil {
 		if ctrlclient.IgnoreNotFound(err) != nil {
 			return nil, err
 		}
 		return nil, nil
 	}
 
-	if authClass.Spec.AuthenticationProvider.OIDC == nil || instance.Spec.ClusterConfigSpec.Authentication.Oidc == nil {
-		oidcLogger.Info("OIDC provider is not configured", "OidcProvider", authClass.Spec.AuthenticationProvider.OIDC, "OidcCredential", instance.Spec.ClusterConfigSpec.Authentication.Oidc)
+	if authClass.Spec.AuthenticationProvider.OIDC == nil || instance.Spec.ClusterConfig.Authentication.Oidc == nil {
+		oidcLogger.Info("OIDC provider is not configured", "OidcProvider", authClass.Spec.AuthenticationProvider.OIDC, "OidcCredential", instance.Spec.ClusterConfig.Authentication.Oidc)
 		return nil, nil
 	}
 
@@ -44,7 +44,7 @@ func MakeOidcContainer(
 		client,
 		instance,
 		authClass.Spec.AuthenticationProvider.OIDC,
-		instance.Spec.ClusterConfigSpec.Authentication.Oidc,
+		instance.Spec.ClusterConfig.Authentication.Oidc,
 		port,
 	)
 	obj := oidc.Build(oidc)

--- a/internal/common/tls.go
+++ b/internal/common/tls.go
@@ -136,7 +136,7 @@ func CreateTlsSecretPvc(secretClass string, jksPassword string) corev1.Volume {
 					Spec: corev1.PersistentVolumeClaimSpec{
 						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 						StorageClassName: func() *string {
-							cs := "secrets.zncdata.dev"
+							cs := "secrets.kubedoop.dev"
 							return &cs
 						}(),
 						VolumeMode: func() *corev1.PersistentVolumeMode { v := corev1.PersistentVolumeFilesystem; return &v }(),

--- a/internal/common/vector.go
+++ b/internal/common/vector.go
@@ -59,7 +59,7 @@ func ExtendConfigMapByVector(ctx context.Context, params VectorConfigParams, dat
 	if err != nil {
 		vectorLogger.Error(errors.Wrap(err, "error creating vector YAML"), "failed to create vector YAML")
 	} else {
-		data[builder.VectorConfigFile] = vectorYaml
+		data[builder.VectorConfigFileName] = vectorYaml
 	}
 }
 

--- a/internal/controller/cluster.go
+++ b/internal/controller/cluster.go
@@ -120,7 +120,7 @@ func (h *HdfsClusterInstance) GetRoleConfigSpec(role common.Role) (any, error) {
 }
 
 func (h *HdfsClusterInstance) GetClusterConfig() any {
-	return h.Instance.Spec.ClusterConfigSpec
+	return h.Instance.Spec.ClusterConfig
 }
 
 func (h *HdfsClusterInstance) GetNamespace() string {

--- a/internal/controller/data/configmap.go
+++ b/internal/controller/data/configmap.go
@@ -61,8 +61,8 @@ func (c *ConfigMapReconciler) Build(ctx context.Context) (client.Object, error) 
 		hdfsv1alpha1.HdfsSiteFileName:     c.makeHdfsSiteData(),
 		hdfsv1alpha1.HadoopPolicyFileName: common.MakeHadoopPolicyData(),
 		hdfsv1alpha1.SecurityFileName:     common.MakeSecurityPropertiesData(),
-		hdfsv1alpha1.SslClientFileName:    common.MakeSslClientData(c.Instance.Spec.ClusterConfigSpec),
-		hdfsv1alpha1.SslServerFileName:    common.MakeSslServerData(c.Instance.Spec.ClusterConfigSpec),
+		hdfsv1alpha1.SslClientFileName:    common.MakeSslClientData(c.Instance.Spec.ClusterConfig),
+		hdfsv1alpha1.SslServerFileName:    common.MakeSslServerData(c.Instance.Spec.ClusterConfig),
 		// log4j
 		common.CreateComponentLog4jPropertiesName(container.DataNode):     common.MakeLog4jPropertiesData(container.DataNode),
 		common.CreateComponentLog4jPropertiesName(container.WaitNameNode): common.MakeLog4jPropertiesData(container.WaitNameNode),
@@ -75,7 +75,7 @@ func (c *ConfigMapReconciler) Build(ctx context.Context) (client.Object, error) 
 			ctx,
 			common.VectorConfigParams{
 				Client:        c.Client,
-				ClusterConfig: c.Instance.Spec.ClusterConfigSpec,
+				ClusterConfig: c.Instance.Spec.ClusterConfig,
 				Namespace:     c.Instance.GetNamespace(),
 				InstanceName:  c.Instance.GetName(),
 				Role:          string(common.DataNode),
@@ -97,12 +97,12 @@ func (c *ConfigMapReconciler) Build(ctx context.Context) (client.Object, error) 
 // make core-site.xml data
 func (c *ConfigMapReconciler) makeCoreSiteData() string {
 	generator := &common.CoreSiteXmlGenerator{InstanceName: c.Instance.GetName()}
-	return generator.EnableKerberos(c.Instance.Spec.ClusterConfigSpec, c.Instance.Namespace).HaZookeeperQuorum().Generate()
+	return generator.EnableKerberos(c.Instance.Spec.ClusterConfig, c.Instance.Namespace).HaZookeeperQuorum().Generate()
 }
 
 // make hdfs-site.xml data
 func (c *ConfigMapReconciler) makeHdfsSiteData() string {
-	clusterSpec := c.Instance.Spec.ClusterConfigSpec
+	clusterSpec := c.Instance.Spec.ClusterConfig
 	generator := common.NewDataNodeHdfsSiteXmlGenerator(c.Instance, c.GroupName, c.getNameNodeReplicas(), c.dataNodeConfig())
 	return generator.EnablerKerberos(clusterSpec).EnableHttps().Generate()
 }

--- a/internal/controller/data/container/datanode.go
+++ b/internal/controller/data/container/datanode.go
@@ -23,7 +23,7 @@ func NewDataNodeContainerBuilder(
 ) *DataNodeContainerBuilder {
 	image := hdfsv1alpha1.TransformImage(instance.Spec.Image)
 	imagePullPolicy := image.GetPullPolicy()
-	clusterConfig := instance.Spec.ClusterConfigSpec
+	clusterConfig := instance.Spec.ClusterConfig
 	return &DataNodeContainerBuilder{
 		ContainerBuilder:       *common.NewContainerBuilder(image.String(), imagePullPolicy, resource),
 		zookeeperConfigMapName: clusterConfig.ZookeeperConfigMapName,

--- a/internal/controller/data/container/init_container.go
+++ b/internal/controller/data/container/init_container.go
@@ -26,7 +26,7 @@ func NewWaitNameNodeContainerBuilder(
 	groupName string,
 ) *WaitNameNodeContainerBuilder {
 	imageSpec := instance.Spec.Image
-	clusterConfigSpec := instance.Spec.ClusterConfigSpec
+	clusterConfigSpec := instance.Spec.ClusterConfig
 	image := hdfsv1alpha1.TransformImage(imageSpec)
 	return &WaitNameNodeContainerBuilder{
 		ContainerBuilder:       *common.NewContainerBuilder(image.String(), image.GetPullPolicy(), resource),
@@ -77,10 +77,10 @@ cp /kubedoop/mount/config/wait-for-namenodes/wait-for-namenodes.log4j.properties
 
 echo "Waiting for namenodes to get ready:"
 n=0
-while [ ${n} -lt 12 ]; 
+while [ ${n} -lt 12 ];
 do
     ALL_NODES_READY=true
-    for namenode_id in ` + w.nameNodeIds() + `; 
+    for namenode_id in ` + w.nameNodeIds() + `;
     do
         echo -n "Checking pod $namenode_id... "
         SERVICE_STATE=$(/kubedoop/hadoop/bin/hdfs haadmin -getServiceState $namenode_id | tail -n1 || true)

--- a/internal/controller/data/statefulset.go
+++ b/internal/controller/data/statefulset.go
@@ -80,7 +80,7 @@ func (s *StatefulSetReconciler) Build(ctx context.Context) (client.Object, error
 		img := hdfsv1alpha1.TransformImage(s.Instance.Spec.Image)
 		common.ExtendStatefulSetByVector(nil, sts, img, createConfigName(s.Instance.GetName(), s.GroupName))
 	}
-	if s.Instance.Spec.ClusterConfigSpec.Authentication != nil && s.Instance.Spec.ClusterConfigSpec.Authentication.AuthenticationClass != "" {
+	if s.Instance.Spec.ClusterConfig.Authentication != nil && s.Instance.Spec.ClusterConfig.Authentication.AuthenticationClass != "" {
 		oidcContainer, err := common.MakeOidcContainer(ctx, s.Client, s.Instance, s.getHttpPort())
 		if err != nil {
 			return nil, err
@@ -93,7 +93,7 @@ func (s *StatefulSetReconciler) Build(ctx context.Context) (client.Object, error
 }
 
 func (s *StatefulSetReconciler) getHttpPort() int32 {
-	return common.HttpPort(s.Instance.Spec.ClusterConfigSpec, hdfsv1alpha1.DataNodeHttpsPort, hdfsv1alpha1.DataNodeHttpPort).ContainerPort
+	return common.HttpPort(s.Instance.Spec.ClusterConfig, hdfsv1alpha1.DataNodeHttpsPort, hdfsv1alpha1.DataNodeHttpPort).ContainerPort
 }
 
 func (s *StatefulSetReconciler) SetAffinity(resource client.Object) {
@@ -158,7 +158,7 @@ func (s *StatefulSetReconciler) makeWaitNameNodeContainer() corev1.Container {
 
 // make volumes
 func (s *StatefulSetReconciler) makeVolumes() []corev1.Volume {
-	volumes := common.GetCommonVolumes(s.Instance.Spec.ClusterConfigSpec, s.Instance.GetName(), container.GetRole())
+	volumes := common.GetCommonVolumes(s.Instance.Spec.ClusterConfig, s.Instance.GetName(), container.GetRole())
 	datanodeVolumes := []corev1.Volume{
 		{
 			Name: hdfsv1alpha1.HdfsConfigVolumeMountName,

--- a/internal/controller/data/svc_headless.go
+++ b/internal/controller/data/svc_headless.go
@@ -73,5 +73,5 @@ func (s *ServiceReconciler) makePorts() []corev1.ServicePort {
 			TargetPort: intstr.FromString("oidc"),
 		},
 	}
-	return append(ports, common.ServiceHttpPort(s.Instance.Spec.ClusterConfigSpec, ServiceHttpsPort, ServiceHttpPort))
+	return append(ports, common.ServiceHttpPort(s.Instance.Spec.ClusterConfig, ServiceHttpsPort, ServiceHttpPort))
 }

--- a/internal/controller/discovery.go
+++ b/internal/controller/discovery.go
@@ -69,7 +69,7 @@ func (d *Discovery) Build(ctx context.Context) (client.Object, error) {
 
 func (d *Discovery) makeCoreSiteXmlData() string {
 	generator := common.CoreSiteXmlGenerator{InstanceName: d.Instance.Name, IsDiscovery: true}
-	return generator.EnableKerberos(d.Instance.Spec.ClusterConfigSpec, d.Instance.Namespace).Generate()
+	return generator.EnableKerberos(d.Instance.Spec.ClusterConfig, d.Instance.Namespace).Generate()
 }
 
 func (d *Discovery) makeHdfsSiteXmlData(ctx context.Context) (string, error) {
@@ -78,7 +78,7 @@ func (d *Discovery) makeHdfsSiteXmlData(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if common.IsKerberosEnabled(d.Instance.Spec.ClusterConfigSpec) {
+	if common.IsKerberosEnabled(d.Instance.Spec.ClusterConfig) {
 		properties = append(properties, common.SecurityDiscoveryHdfsSiteXml()...)
 	}
 	return xml.String(properties), nil
@@ -196,7 +196,7 @@ func (d *Discovery) createConnections(ctx context.Context, podNames []string) ([
 	var connections []util.XmlNameValuePair
 	// create http address
 	schema := "http"
-	if common.IsTlsEnabled(d.Instance.Spec.ClusterConfigSpec) {
+	if common.IsTlsEnabled(d.Instance.Spec.ClusterConfig) {
 		schema = "https"
 	}
 	httpConnections, err = d.createPortNameAddress(ctx, podNames, schema, &cache)

--- a/internal/controller/hdfscluster_controller.go
+++ b/internal/controller/hdfscluster_controller.go
@@ -37,17 +37,17 @@ type HdfsClusterReconciler struct {
 	Log    logr.Logger
 }
 
-// +kubebuilder:rbac:groups=listeners.zncdata.dev,resources=listeners,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=hdfs.zncdata.dev,resources=hdfsclusters,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=hdfs.zncdata.dev,resources=hdfsclusters/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=hdfs.zncdata.dev,resources=hdfsclusters/finalizers,verbs=update
+// +kubebuilder:rbac:groups=listeners.kubedoop.dev,resources=listeners,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=hdfs.kubedoop.dev,resources=hdfsclusters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=hdfs.kubedoop.dev,resources=hdfsclusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=hdfs.kubedoop.dev,resources=hdfsclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
-// +kubebuilder:rbac:groups=authentication.zncdata.dev,resources=authenticationclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=authentication.kubedoop.dev,resources=authenticationclasses,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/journal/configmap.go
+++ b/internal/controller/journal/configmap.go
@@ -59,8 +59,8 @@ func (c *ConfigMapReconciler) Build(ctx context.Context) (client.Object, error) 
 		hdfsv1alpha1.HdfsSiteFileName:     c.makeHdfsSiteData(),
 		hdfsv1alpha1.HadoopPolicyFileName: common.MakeHadoopPolicyData(),
 		hdfsv1alpha1.SecurityFileName:     common.MakeSecurityPropertiesData(),
-		hdfsv1alpha1.SslClientFileName:    common.MakeSslClientData(c.Instance.Spec.ClusterConfigSpec),
-		hdfsv1alpha1.SslServerFileName:    common.MakeSslServerData(c.Instance.Spec.ClusterConfigSpec),
+		hdfsv1alpha1.SslClientFileName:    common.MakeSslClientData(c.Instance.Spec.ClusterConfig),
+		hdfsv1alpha1.SslServerFileName:    common.MakeSslServerData(c.Instance.Spec.ClusterConfig),
 		// log4j
 		common.CreateComponentLog4jPropertiesName(ContainerJournalNode): common.MakeLog4jPropertiesData(ContainerJournalNode),
 	}
@@ -72,7 +72,7 @@ func (c *ConfigMapReconciler) Build(ctx context.Context) (client.Object, error) 
 			ctx,
 			common.VectorConfigParams{
 				Client:        c.Client,
-				ClusterConfig: c.Instance.Spec.ClusterConfigSpec,
+				ClusterConfig: c.Instance.Spec.ClusterConfig,
 				Namespace:     c.Instance.GetNamespace(),
 				InstanceName:  c.Instance.GetName(),
 				Role:          string(common.JournalNode),
@@ -94,15 +94,15 @@ func (c *ConfigMapReconciler) Build(ctx context.Context) (client.Object, error) 
 // make core-site.xml data
 func (c *ConfigMapReconciler) makeCoreSiteData() string {
 	generator := &common.CoreSiteXmlGenerator{InstanceName: c.Instance.GetName()}
-	return generator.EnableKerberos(c.Instance.Spec.ClusterConfigSpec, c.Instance.Namespace).HaZookeeperQuorum().Generate()
+	return generator.EnableKerberos(c.Instance.Spec.ClusterConfig, c.Instance.Namespace).HaZookeeperQuorum().Generate()
 }
 
 // make hdfs-site.xml data
 func (c *ConfigMapReconciler) makeHdfsSiteData() string {
-	clusterSpec := c.Instance.Spec.ClusterConfigSpec
+	clusterSpec := c.Instance.Spec.ClusterConfig
 	generator := common.NewNameNodeHdfsSiteXmlGenerator(
 		c.Instance.GetName(), c.GroupName, c.getNameNodeReplicas(), c.Instance.Namespace,
-		c.Instance.Spec.ClusterConfigSpec, clusterSpec.ClusterDomain, clusterSpec.DfsReplication)
+		c.Instance.Spec.ClusterConfig, clusterSpec.ClusterDomain, clusterSpec.DfsReplication)
 	return generator.EnablerKerberos(clusterSpec).EnableHttps().Generate()
 }
 

--- a/internal/controller/journal/container.go
+++ b/internal/controller/journal/container.go
@@ -23,7 +23,7 @@ func NewJournalNodeContainerBuilder(
 ) *ContainerBuilder {
 	imageSpec := instance.Spec.Image
 	image := hdfsv1alpha1.TransformImage(imageSpec)
-	clusterConfig := instance.Spec.ClusterConfigSpec
+	clusterConfig := instance.Spec.ClusterConfig
 	return &ContainerBuilder{
 		ContainerBuilder:       *common.NewContainerBuilder(image.String(), image.GetPullPolicy(), resource),
 		zookeeperConfigMapName: clusterConfig.ZookeeperConfigMapName,

--- a/internal/controller/journal/container_test.go
+++ b/internal/controller/journal/container_test.go
@@ -22,7 +22,7 @@ var _ = Describe("CommandArgs", func() {
 			}
 			builder := journal.NewJournalNodeContainerBuilder(&hdfsv1alpha1.HdfsCluster{
 				Spec: hdfsv1alpha1.HdfsClusterSpec{
-					ClusterConfigSpec: clusterConfig,
+					ClusterConfig: clusterConfig,
 				},
 			}, corev1.ResourceRequirements{})
 
@@ -49,7 +49,7 @@ var _ = Describe("CommandArgs", func() {
 			}
 			builder := journal.NewJournalNodeContainerBuilder(&hdfsv1alpha1.HdfsCluster{
 				Spec: hdfsv1alpha1.HdfsClusterSpec{
-					ClusterConfigSpec: clusterConfig,
+					ClusterConfig: clusterConfig,
 				},
 			}, corev1.ResourceRequirements{})
 

--- a/internal/controller/journal/statefulset.go
+++ b/internal/controller/journal/statefulset.go
@@ -74,7 +74,7 @@ func (s *StatefulSetReconciler) Build(ctx context.Context) (client.Object, error
 		img := hdfsv1alpha1.TransformImage(s.Instance.Spec.Image)
 		common.ExtendStatefulSetByVector(nil, sts, img, createConfigName(s.Instance.GetName(), s.GroupName))
 	}
-	if s.Instance.Spec.ClusterConfigSpec.Authentication != nil && s.Instance.Spec.ClusterConfigSpec.Authentication.AuthenticationClass != "" {
+	if s.Instance.Spec.ClusterConfig.Authentication != nil && s.Instance.Spec.ClusterConfig.Authentication.AuthenticationClass != "" {
 		oidcContainer, err := common.MakeOidcContainer(ctx, s.Client, s.Instance, s.getHttpPort())
 		if err != nil {
 			return nil, err
@@ -87,7 +87,7 @@ func (s *StatefulSetReconciler) Build(ctx context.Context) (client.Object, error
 }
 
 func (s *StatefulSetReconciler) getHttpPort() int32 {
-	return common.HttpPort(s.Instance.Spec.ClusterConfigSpec, hdfsv1alpha1.JournalNodeHttpsPort, hdfsv1alpha1.JournalNodeHttpPort).ContainerPort
+	return common.HttpPort(s.Instance.Spec.ClusterConfig, hdfsv1alpha1.JournalNodeHttpsPort, hdfsv1alpha1.JournalNodeHttpPort).ContainerPort
 }
 
 func (s *StatefulSetReconciler) SetAffinity(resource client.Object) {
@@ -141,7 +141,7 @@ func (s *StatefulSetReconciler) makeJournalNodeContainer() corev1.Container {
 
 // make volumes
 func (s *StatefulSetReconciler) makeVolumes() []corev1.Volume {
-	volumes := common.GetCommonVolumes(s.Instance.Spec.ClusterConfigSpec, s.Instance.GetName(), GetRole())
+	volumes := common.GetCommonVolumes(s.Instance.Spec.ClusterConfig, s.Instance.GetName(), GetRole())
 	journalNodeVolumes := []corev1.Volume{
 		{
 			Name: hdfsv1alpha1.HdfsConfigVolumeMountName,

--- a/internal/controller/journal/svc_headless.go
+++ b/internal/controller/journal/svc_headless.go
@@ -67,5 +67,5 @@ func (s *ServiceReconciler) makePorts() []corev1.ServicePort {
 			TargetPort: intstr.FromString("oidc"),
 		},
 	}
-	return append(ports, common.ServiceHttpPort(s.Instance.Spec.ClusterConfigSpec, ServiceHttpsPort, ServiceHttpPort))
+	return append(ports, common.ServiceHttpPort(s.Instance.Spec.ClusterConfig, ServiceHttpsPort, ServiceHttpPort))
 }

--- a/internal/controller/name/configmap.go
+++ b/internal/controller/name/configmap.go
@@ -61,8 +61,8 @@ func (c *ConfigMapReconciler) Build(ctx context.Context) (client.Object, error) 
 		hdfsv1alpha1.HdfsSiteFileName:     c.makeHdfsSiteData(),
 		hdfsv1alpha1.HadoopPolicyFileName: common.MakeHadoopPolicyData(),
 		hdfsv1alpha1.SecurityFileName:     common.MakeSecurityPropertiesData(),
-		hdfsv1alpha1.SslClientFileName:    common.MakeSslClientData(c.Instance.Spec.ClusterConfigSpec),
-		hdfsv1alpha1.SslServerFileName:    common.MakeSslServerData(c.Instance.Spec.ClusterConfigSpec),
+		hdfsv1alpha1.SslClientFileName:    common.MakeSslClientData(c.Instance.Spec.ClusterConfig),
+		hdfsv1alpha1.SslServerFileName:    common.MakeSslServerData(c.Instance.Spec.ClusterConfig),
 		// log4j
 		common.CreateComponentLog4jPropertiesName(container.NameNode):        common.MakeLog4jPropertiesData(container.NameNode),
 		common.CreateComponentLog4jPropertiesName(container.Zkfc):            common.MakeLog4jPropertiesData(container.Zkfc),
@@ -77,7 +77,7 @@ func (c *ConfigMapReconciler) Build(ctx context.Context) (client.Object, error) 
 			ctx,
 			common.VectorConfigParams{
 				Client:        c.Client,
-				ClusterConfig: c.Instance.Spec.ClusterConfigSpec,
+				ClusterConfig: c.Instance.Spec.ClusterConfig,
 				Namespace:     c.Instance.GetNamespace(),
 				InstanceName:  c.Instance.GetName(),
 				Role:          string(common.NameNode),
@@ -99,14 +99,14 @@ func (c *ConfigMapReconciler) Build(ctx context.Context) (client.Object, error) 
 // make core-site.xml data
 func (c *ConfigMapReconciler) makeCoreSiteData() string {
 	generator := &common.CoreSiteXmlGenerator{InstanceName: c.Instance.GetName()}
-	return generator.EnableKerberos(c.Instance.Spec.ClusterConfigSpec, c.Instance.Namespace).HaZookeeperQuorum().Generate()
+	return generator.EnableKerberos(c.Instance.Spec.ClusterConfig, c.Instance.Namespace).HaZookeeperQuorum().Generate()
 }
 
 // make hdfs-site.xml data
 func (c *ConfigMapReconciler) makeHdfsSiteData() string {
-	clusterSpec := c.Instance.Spec.ClusterConfigSpec
+	clusterSpec := c.Instance.Spec.ClusterConfig
 	generator := common.NewNameNodeHdfsSiteXmlGenerator(c.Instance.GetName(), c.GroupName,
-		c.MergedCfg.Replicas, c.Instance.Namespace, c.Instance.Spec.ClusterConfigSpec, clusterSpec.ClusterDomain,
+		c.MergedCfg.Replicas, c.Instance.Namespace, c.Instance.Spec.ClusterConfig, clusterSpec.ClusterDomain,
 		clusterSpec.DfsReplication)
 	return generator.EnablerKerberos(clusterSpec).EnableHttps().Generate()
 }

--- a/internal/controller/name/container/format_namenode.go
+++ b/internal/controller/name/container/format_namenode.go
@@ -31,7 +31,7 @@ func NewFormatNameNodeContainerBuilder(
 ) *FormatNameNodeContainerBuilder {
 	imageSpec := instance.Spec.Image
 	image := hdfsv1alpha1.TransformImage(imageSpec)
-	clusterConfig := instance.Spec.ClusterConfigSpec
+	clusterConfig := instance.Spec.ClusterConfig
 	return &FormatNameNodeContainerBuilder{
 		ContainerBuilder:       *common.NewContainerBuilder(image.String(), image.GetPullPolicy(), resource),
 		zookeeperConfigMapName: clusterConfig.ZookeeperConfigMapName,

--- a/internal/controller/name/container/format_zk.go
+++ b/internal/controller/name/container/format_zk.go
@@ -27,7 +27,7 @@ func NewFormatZookeeperContainerBuilder(
 		ContainerBuilder:       *common.NewContainerBuilder(image.String(), image.GetPullPolicy(), resource),
 		zookeeperConfigMapName: zookeeperConfigMapName,
 		namespace:              instance.Namespace,
-		clusterConfig:          instance.Spec.ClusterConfigSpec,
+		clusterConfig:          instance.Spec.ClusterConfig,
 	}
 }
 

--- a/internal/controller/name/container/namenode.go
+++ b/internal/controller/name/container/namenode.go
@@ -22,11 +22,11 @@ func NewNameNodeContainerBuilder(
 	resource corev1.ResourceRequirements) *NameNodeContainerBuilder {
 	imageSpec := instance.Spec.Image
 	image := hdfsv1alpha1.TransformImage(imageSpec)
-	zookeeperConfigMapName := instance.Spec.ClusterConfigSpec.ZookeeperConfigMapName
+	zookeeperConfigMapName := instance.Spec.ClusterConfig.ZookeeperConfigMapName
 	return &NameNodeContainerBuilder{
 		ContainerBuilder:       *common.NewContainerBuilder(image.String(), image.GetPullPolicy(), resource),
 		zookeeperConfigMapName: zookeeperConfigMapName,
-		clusterConfig:          instance.Spec.ClusterConfigSpec,
+		clusterConfig:          instance.Spec.ClusterConfig,
 	}
 }
 

--- a/internal/controller/name/container/zkfc.go
+++ b/internal/controller/name/container/zkfc.go
@@ -20,7 +20,7 @@ func NewZkfcContainerBuilder(
 ) *ZkfcContainerBuilder {
 	imageSpec := instance.Spec.Image
 	image := hdfsv1alpha1.TransformImage(imageSpec)
-	clusterConfig := instance.Spec.ClusterConfigSpec
+	clusterConfig := instance.Spec.ClusterConfig
 	zookeeperConfigMapName := clusterConfig.ZookeeperConfigMapName
 	return &ZkfcContainerBuilder{
 		ContainerBuilder:       *common.NewContainerBuilder(image.String(), image.GetPullPolicy(), resource),

--- a/internal/controller/name/statefulset.go
+++ b/internal/controller/name/statefulset.go
@@ -88,7 +88,7 @@ func (s *StatefulSetReconciler) Build(ctx context.Context) (client.Object, error
 		common.ExtendStatefulSetByVector(nil, sts, img, createConfigName(s.Instance.GetName(), s.GroupName))
 	}
 
-	if s.Instance.Spec.ClusterConfigSpec.Authentication != nil && s.Instance.Spec.ClusterConfigSpec.Authentication.AuthenticationClass != "" {
+	if s.Instance.Spec.ClusterConfig.Authentication != nil && s.Instance.Spec.ClusterConfig.Authentication.AuthenticationClass != "" {
 		oidcContainer, err := common.MakeOidcContainer(ctx, s.Client, s.Instance, s.getHttpPort())
 		if err != nil {
 			return nil, err
@@ -102,7 +102,7 @@ func (s *StatefulSetReconciler) Build(ctx context.Context) (client.Object, error
 }
 
 func (s *StatefulSetReconciler) getHttpPort() int32 {
-	return common.HttpPort(s.Instance.Spec.ClusterConfigSpec, hdfsv1alpha1.NameNodeHttpsPort, hdfsv1alpha1.NameNodeHttpPort).ContainerPort
+	return common.HttpPort(s.Instance.Spec.ClusterConfig, hdfsv1alpha1.NameNodeHttpsPort, hdfsv1alpha1.NameNodeHttpPort).ContainerPort
 }
 
 func (s *StatefulSetReconciler) SetAffinity(resource client.Object) {
@@ -186,7 +186,7 @@ func (s *StatefulSetReconciler) makeFormatZookeeperContainer() corev1.Container 
 
 // make volumes
 func (s *StatefulSetReconciler) makeVolumes() []corev1.Volume {
-	volumes := common.GetCommonVolumes(s.Instance.Spec.ClusterConfigSpec, s.Instance.GetName(), container.GetRole())
+	volumes := common.GetCommonVolumes(s.Instance.Spec.ClusterConfig, s.Instance.GetName(), container.GetRole())
 	nameNodeVolumes := []corev1.Volume{
 		{
 			Name: hdfsv1alpha1.HdfsConfigVolumeMountName,
@@ -290,5 +290,5 @@ func (s *StatefulSetReconciler) getNameNodeConfigMapSource() *corev1.ConfigMapVo
 
 // get zookeeper discovery znode
 func (s *StatefulSetReconciler) getZookeeperConfigMapName() string {
-	return s.Instance.Spec.ClusterConfigSpec.ZookeeperConfigMapName
+	return s.Instance.Spec.ClusterConfig.ZookeeperConfigMapName
 }

--- a/internal/controller/name/svc_headless.go
+++ b/internal/controller/name/svc_headless.go
@@ -67,5 +67,5 @@ func (s *ServiceReconciler) makePorts() []corev1.ServicePort {
 			TargetPort: intstr.FromString("oidc"),
 		},
 	}
-	return append(ports, common.ServiceHttpPort(s.Instance.Spec.ClusterConfigSpec, ServiceHttpsPort, ServiceHttpPort))
+	return append(ports, common.ServiceHttpPort(s.Instance.Spec.ClusterConfig, ServiceHttpsPort, ServiceHttpPort))
 }

--- a/test/e2e/default/hdfs.yaml
+++ b/test/e2e/default/hdfs.yaml
@@ -1,4 +1,4 @@
-apiVersion: hdfs.zncdata.dev/v1alpha1
+apiVersion: hdfs.kubedoop.dev/v1alpha1
 kind: HdfsCluster
 metadata:
   labels:
@@ -34,7 +34,7 @@ spec:
       default:
         replicas: 1
         config:
-          resources: 
+          resources:
             cpu:
               min: 200m
               max: 800m

--- a/test/e2e/oidc/authenticationclass.yaml
+++ b/test/e2e/oidc/authenticationclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: authentication.zncdata.dev/v1alpha1
+apiVersion: authentication.kubedoop.dev/v1alpha1
 kind: AuthenticationClass
 metadata:
   name: oidc

--- a/test/e2e/oidc/hdfs.yaml
+++ b/test/e2e/oidc/hdfs.yaml
@@ -1,4 +1,4 @@
-apiVersion: hdfs.zncdata.dev/v1alpha1
+apiVersion: hdfs.kubedoop.dev/v1alpha1
 kind: HdfsCluster
 metadata:
   labels:

--- a/test/e2e/setup/zookeeper.yaml
+++ b/test/e2e/setup/zookeeper.yaml
@@ -22,16 +22,6 @@ spec:
     roleGroups:
       default:
         replicas: 1
-        config:
-          logging:
-            zookeeperCluster:
-              loggers:
-                test:
-                  level: DEBUG
-              console:
-                level: WARN
-              file:
-                level: INFO
 ---
 apiVersion: zookeeper.kubedoop.dev/v1alpha1
 kind: ZookeeperZnode

--- a/test/e2e/setup/zookeeper.yaml
+++ b/test/e2e/setup/zookeeper.yaml
@@ -1,4 +1,4 @@
-apiVersion: zookeeper.zncdata.dev/v1alpha1
+apiVersion: zookeeper.kubedoop.dev/v1alpha1
 kind: ZookeeperCluster
 metadata:
   labels:
@@ -33,7 +33,7 @@ spec:
               file:
                 level: INFO
 ---
-apiVersion: zookeeper.zncdata.dev/v1alpha1
+apiVersion: zookeeper.kubedoop.dev/v1alpha1
 kind: ZookeeperZnode
 metadata:
   labels:
@@ -46,4 +46,3 @@ metadata:
 spec:
   clusterRef:
     name: zookeepercluster-sample
-

--- a/test/e2e/vector/hdfs.yaml
+++ b/test/e2e/vector/hdfs.yaml
@@ -1,4 +1,4 @@
-apiVersion: hdfs.zncdata.dev/v1alpha1
+apiVersion: hdfs.kubedoop.dev/v1alpha1
 kind: HdfsCluster
 metadata:
   labels:
@@ -34,4 +34,3 @@ spec:
         config:
           logging:
             enableVectorAgent: true
-


### PR DESCRIPTION
- **refactor: bump domain to kubedoop.dev**
- **refactor: bump operator-go to 0.12-dev**

Part of https://github.com/zncdatadev/trino-operator/issues/191
