### PR TITLE
fix: use CR spec productVersion in GetImage() and update default to 3.4.1

### DIFF
--- a/api/v1alpha1/image.go
+++ b/api/v1alpha1/image.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	DefaultRepository     = "quay.io/zncdatadev"
-	DefaultProductVersion = "3.3.6"
+	DefaultProductVersion = "3.4.1"
 	DefaultProductName    = "hadoop"
 )
 

--- a/internal/controller/cluster.go
+++ b/internal/controller/cluster.go
@@ -52,10 +52,15 @@ func NewClusterReconciler(
 
 // GetImage returns the image configuration for HDFS components
 func (r *Reconciler) GetImage(roleType constant.Role) *util.Image {
+	productVersion := r.Spec.Image.ProductVersion
+	if productVersion == "" {
+		productVersion = hdfsv1alpha1.DefaultProductVersion
+	}
+
 	image := util.NewImage(
 		hdfsv1alpha1.DefaultProductName,
 		version.BuildVersion,
-		hdfsv1alpha1.DefaultProductVersion,
+		productVersion,
 		func(options *util.ImageOptions) {
 			options.Custom = r.Spec.Image.Custom
 			options.Repo = r.Spec.Image.Repo


### PR DESCRIPTION
## Summary

Same issue as zookeeper-operator #348. `GetImage()` was hardcoded to use `DefaultProductVersion` (3.3.6), ignoring the `productVersion` field set in the HDFSCluster CR spec.

## Changes
- **cluster.go**: Honor `r.Spec.Image.ProductVersion` when set, fallback to `DefaultProductVersion`
- **image.go**: Update `DefaultProductVersion` from 3.3.6 to 3.4.1 (latest stable, per `zncdata-containers/hadoop/versions.yaml`)

## Impact
Prevents potential `ImagePullBackOff` when DefaultProductVersion is out of sync with the product-version matrix.