### PR TITLE
test: uncomment k8s-version matrix in test.yml to match release.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
     strategy:
       matrix:
         k8s-version: [
-          # '1.33.7',
-          # '1.34.3',
+          '1.33.7',
+          '1.34.3',
           '1.35.0'
         ]
         product-version: ['3.3.6','3.4.1']


### PR DESCRIPTION
Supplement to #305. `test.yml` k8s-version matrix had `1.33.7` and `1.34.3` commented out, not matching `release.yml`. Uncomment to align with baseline.